### PR TITLE
fix bug: when " in string, need add ecape character \

### DIFF
--- a/generators/arduino.js
+++ b/generators/arduino.js
@@ -314,6 +314,7 @@ Blockly.Arduino.quote_ = function(string) {
   string = string.replace(/\\/g, '\\\\')
       .replace(/\n/g, '\\\n')
       .replace(/\$/g, '\\$')
+      .replace(/"/g, '\\"')
       .replace(/'/g, '\\\'');
   return '"' + string + '"';
 };


### PR DESCRIPTION

### Reason for Changes

 when " in string, need add ecape character \
